### PR TITLE
Replace Source-based implementation / API with iterator based one

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import bintray.Keys._
 
 name := "Scala OpenBook"
 
-version := "0.0.7"
+version := "0.0.8"
 
 organization := "com.scalafi"
 
@@ -46,3 +46,6 @@ bintrayPublishSettings
 repository in bintray := "releases"
 
 bintrayOrganization in bintray := None
+
+// Let's be nice to eclipse users:
+EclipseKeys.withSource := true

--- a/build.sbt
+++ b/build.sbt
@@ -46,6 +46,3 @@ bintrayPublishSettings
 repository in bintray := "releases"
 
 bintrayOrganization in bintray := None
-
-// Let's be nice to eclipse users:
-EclipseKeys.withSource := true

--- a/src/main/scala/com/scalafi/openbook/ByteArrayIterator.scala
+++ b/src/main/scala/com/scalafi/openbook/ByteArrayIterator.scala
@@ -2,7 +2,11 @@ package com.scalafi.openbook
 
 import java.io.InputStream
 
-
+/**
+ * Wraps an input stream into an `Iterator` interface. Note that the underlying Array[Byte]
+ * is NOT re-allocated. So the iterator itself assumes that the message is consumed / interpreted
+ * before the next call to `next`.
+ */
 final class ByteArrayIterator(is : InputStream, len : Int) extends Iterator[Array[Byte]] {
 
   assume(len > 0, s"Message length must be positive. Found: ${len}")

--- a/src/main/scala/com/scalafi/openbook/ByteArrayIterator.scala
+++ b/src/main/scala/com/scalafi/openbook/ByteArrayIterator.scala
@@ -1,0 +1,52 @@
+package com.scalafi.openbook
+
+import java.io.InputStream
+
+
+final class ByteArrayIterator(is : InputStream, len : Int) extends Iterator[Array[Byte]] {
+
+  assume(len > 0, s"Message length must be positive. Found: ${len}")
+  
+  private val buf = new Array[Byte](len);
+  private var done, full = false : Boolean;
+
+  def next() = {
+    if (full)
+      // next message already buffered
+    {
+      full = false;
+      buf
+    }
+    else
+    {
+      // see if we can buffer next message, if so, return that one
+      if (hasNext()) next()
+      else throw new NoSuchElementException("next on empty iterator")
+    }
+  }
+
+  def hasNext() = {
+    if (done) false
+    else if (full) true
+    else {
+      val nBytesRead = is.read(buf)
+      if (nBytesRead == len)
+        // cool, read a whole message
+      {
+        full = true
+        full
+      }
+      else if (nBytesRead == -1)
+      // end of buffer has been reached
+      {
+        is.close()
+        done = true
+        false
+      }
+      else
+      {
+        throw new NoSuchElementException(s"Expected message length of ${len}, but could read only ${nBytesRead}.")
+      }
+    }
+  }
+}

--- a/src/main/scala/com/scalafi/openbook/OpenBookMsg.scala
+++ b/src/main/scala/com/scalafi/openbook/OpenBookMsg.scala
@@ -147,6 +147,7 @@ object OpenBookMsg extends Parser {
     iterate(new BufferedInputStream(new FileInputStream(filename)))
 
   def iterate(is: InputStream) : Iterator[OpenBookMsg] =
+    // the underlying iterator is not thread-safe, however, the returned iterator is:
     new ByteArrayIterator(is, msgLength).map(OpenBookMsg.apply)
 }
 

--- a/src/main/scala/com/scalafi/openbook/OpenBookMsg.scala
+++ b/src/main/scala/com/scalafi/openbook/OpenBookMsg.scala
@@ -2,10 +2,12 @@ package com.scalafi.openbook
 
 import java.io.InputStream
 import java.nio.ByteBuffer
-
 import scala.io.{Codec, Source}
 import scalaz.concurrent.Task
 import scalaz.stream._
+import java.io.FileInputStream
+import java.io.File
+import java.io.BufferedInputStream
 
 
 private[openbook] trait Parser {
@@ -66,6 +68,11 @@ private[openbook] trait Parser {
 
 object OpenBookMsg extends Parser {
 
+  /**
+   * Number of bytes per message:
+   */
+  val msgLength = 69
+  
   private object Layout {
     val MsgSeqNum           = 1  -> 4
     val MsgType             = 5  -> 6
@@ -94,7 +101,7 @@ object OpenBookMsg extends Parser {
   }
 
   def apply(bytes: Array[Byte]): OpenBookMsg = {
-    assume(bytes.length == 69, s"Unexpected message length: ${bytes.length}")
+    assume(bytes.length == msgLength, s"Unexpected message length: ${bytes.length}")
 
     implicit val b = bytes
 
@@ -123,31 +130,26 @@ object OpenBookMsg extends Parser {
       parse[Int](Layout.LinkID3)
     )
   }
+
+  def read(filename: File) : Process[Task, OpenBookMsg] =  
+    read(new BufferedInputStream(new FileInputStream(filename)))
   
-  def read(filename: String)(implicit codec: Codec): Process[Task, OpenBookMsg] =  
-    read(Source.fromFile(filename)(codec))
-  
-  def read(is: InputStream)(implicit codec: Codec): Process[Task, OpenBookMsg] =
-    read(Source.fromInputStream(is)(codec))
-  
-  def read(src: Source): Process[Task, OpenBookMsg] = {
+  def read(is: InputStream) : Process[Task, OpenBookMsg] = {
+
     import scalaz.stream.io.resource
-    resource(Task.delay(src))(src => Task.delay(src.close())) { src =>
-      lazy val lines = src.map(_.toByte).grouped(69).map(_.toArray)
-      Task.delay { if (lines.hasNext) OpenBookMsg(lines.next()) else throw Cause.Terminated(Cause.End) }
+    resource(Task.delay(is))(src => Task.delay(src.close())) { src =>
+      lazy val lines = iterate(is)
+      Task.delay { if (lines.hasNext) lines.next() else throw Cause.Terminated(Cause.End) }
     }
   }
 
-  def iterate(filename: String)(implicit codec: Codec): Iterator[OpenBookMsg] =
-    iterate(Source.fromFile(filename)(codec))
+  def iterate(filename: File) : Iterator[OpenBookMsg] =
+    iterate(new BufferedInputStream(new FileInputStream(filename)))
 
-  def iterate(is: InputStream)(implicit codec: Codec): Iterator[OpenBookMsg] =
-    iterate(Source.fromInputStream(is)(codec))
-
-  def iterate(src: Source): Iterator[OpenBookMsg] = {
-    src.map(_.toByte).grouped(69).map(_.toArray).map(OpenBookMsg.apply)
-  }
+  def iterate(is: InputStream) : Iterator[OpenBookMsg] =
+    new ByteArrayIterator(is, msgLength).map(OpenBookMsg.apply)
 }
+
 
 case class OpenBookMsg(msgSeqNum: Int,
                        msgType: MsgType,


### PR DESCRIPTION
The upside(s) being as follows:
- no `Codec` required on the API call (not even implicitly), making the API simpler (especially for calls from java).
- no conversion `byte` -> `char` (two bytes) -> `byte`
- no intermediate allocation of `byte[69]`.

While the implementation might be construed to be a bit more complex (certainly less idiomatic), the API is simpler IMHO. And the performance improvement should be noticeable.

Also made the following cosmetic changes:
- replaced `String` argument with `File` argument for the corresponding API calls, as this is anyhow what's done under the hood, and I believe that it's good to be explicit about the API talking about a file path in this context.
- bumped version number 0.0.7 -> 0.0.8, since it _is_ an API-breaking change.
