### PR TITLE
More Old And Busted Iterator Hotness

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,18 +19,9 @@ scalacOptions += "-feature"
 
 // Resolvers
 
-resolvers += "Scalaz Bintray Repo" at "http://dl.bintray.com/scalaz/releases"
-
 resolvers ++= Seq(
   Resolver.sonatypeRepo("releases"),
   Resolver.sonatypeRepo("snapshots")
-)
-
-// Library Dependencies
-
-libraryDependencies ++= Seq(
-  "org.scalaz"        %% "scalaz-core"   % "7.1.0",
-  "org.scalaz.stream" %% "scalaz-stream" % "0.5a"
 )
 
 // Test Dependencies

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import bintray.Keys._
 
 name := "Scala OpenBook"
 
-version := "0.0.8"
+version := "0.0.9"
 
 organization := "com.scalafi"
 

--- a/src/main/scala/com/scalafi/openbook/OpenBookMsg.scala
+++ b/src/main/scala/com/scalafi/openbook/OpenBookMsg.scala
@@ -2,9 +2,6 @@ package com.scalafi.openbook
 
 import java.io.InputStream
 import java.nio.ByteBuffer
-import scala.io.{Codec, Source}
-import scalaz.concurrent.Task
-import scalaz.stream._
 import java.io.FileInputStream
 import java.io.File
 import java.io.BufferedInputStream
@@ -129,18 +126,6 @@ object OpenBookMsg extends Parser {
       parse[Int](Layout.LinkID2),
       parse[Int](Layout.LinkID3)
     )
-  }
-
-  def read(filename: File) : Process[Task, OpenBookMsg] =  
-    read(new BufferedInputStream(new FileInputStream(filename)))
-  
-  def read(is: InputStream) : Process[Task, OpenBookMsg] = {
-
-    import scalaz.stream.io.resource
-    resource(Task.delay(is))(src => Task.delay(src.close())) { src =>
-      lazy val lines = iterate(is)
-      Task.delay { if (lines.hasNext) lines.next() else throw Cause.Terminated(Cause.End) }
-    }
   }
 
   def iterate(filename: File) : Iterator[OpenBookMsg] =

--- a/src/main/scala/com/scalafi/openbook/orderbook/OrderBook.scala
+++ b/src/main/scala/com/scalafi/openbook/orderbook/OrderBook.scala
@@ -2,18 +2,15 @@ package com.scalafi.openbook.orderbook
 
 import scala.collection.immutable.TreeMap
 import com.scalafi.openbook.{Side, OpenBookMsg}
-import scalaz.concurrent.Task
 
 object OrderBook {
 
-  import scalaz.stream.Process
-
   def empty(symbol: String): OrderBook = new OrderBook(symbol)
 
-  def fromOrders(symbol: String, orders: Process[Task, OpenBookMsg]): Process[Task, OrderBook] =
-    orders.scan(OrderBook(symbol)) {
-      (ob, order) => ob.update(order)
-    }
+  def fromOrders(symbol: String, orders: Iterator[OpenBookMsg]): Iterator[OrderBook] = {
+    val ob = empty(symbol)
+    orders.map { ob.update(_) }
+  }
 }
 
 case class OrderBook(symbol: String,

--- a/src/test/scala/com/scalafi/openbook/OpenBookParserSpec.scala
+++ b/src/test/scala/com/scalafi/openbook/OpenBookParserSpec.scala
@@ -20,9 +20,8 @@ class OpenBookParserSpec extends FlatSpec {
   it should "stream it from InputStream" in {
     val is = this.getClass.getResourceAsStream("/openbookultraAA_N20130403_1_of_1")
 
-    val orders = OpenBookMsg.read(is)
-    val parsed = orders.runLog.run
-    assert(parsed.size == 1000)
+    val orders = OpenBookMsg.iterate(is)
+    assert(orders.size == 1000)
   }
 
   it should "build iterator from InputStream" in {


### PR DESCRIPTION
No disrespect to the developers of `scalaz`, but making a dependency on `Process` when really we're talking about iteration is a bit on the heavy-handed side of things, especially when an iterator can be lifted into a process nearly effortlessly via `Process.emitAll(it.toSeq)`.

This proposed patch removes the dependency on `scalaz` entirely after re-phrasing things in terms of `Iterator`s.
