### PR TITLE
New Feature: Create Stream of OrderBooks from Stream of OrderMessages

### DIFF
--- a/src/main/scala/com/scalafi/openbook/orderbook/OrderBook.scala
+++ b/src/main/scala/com/scalafi/openbook/orderbook/OrderBook.scala
@@ -18,7 +18,8 @@ object OrderBook {
 	}
 
 	/**
-	 * Time series of OrderBooks for a stream of order messages for a multiple symbols:
+	 * Time series of OrderBooks for a stream of order messages for a multiple symbols.
+   * The iterator will always return the order book corresponding to the most recent message.
 	 */
 	def fromOrders(orders: Iterator[OpenBookMsg]): Iterator[OrderBook] = {
 		val obs = new HashMap[String, OrderBook];

--- a/src/main/scala/com/scalafi/openbook/orderbook/OrderBook.scala
+++ b/src/main/scala/com/scalafi/openbook/orderbook/OrderBook.scala
@@ -47,8 +47,7 @@ object OrderBook {
 
 case class OrderBook(symbol: String,
 		buy: TreeMap[Int, Int] = TreeMap.empty,
-		sell: TreeMap[Int, Int] = TreeMap.empty,
-    lastMsg : OpenBookMsg = null // old people style, crusty and fast
+		sell: TreeMap[Int, Int] = TreeMap.empty
     ) {
 
 	def update(order: OpenBookMsg): OrderBook = {
@@ -56,18 +55,18 @@ case class OrderBook(symbol: String,
 
 			order match {
 			case _ if order.side == Side.Buy & order.volume > 0 =>
-			copy(buy = buy + (order.priceNumerator -> order.volume), lastMsg = order)
+			copy(buy = buy + (order.priceNumerator -> order.volume))
 
 			case _ if order.side == Side.Buy & order.volume == 0 =>
-			copy(buy = buy - order.priceNumerator, lastMsg = order)
+			copy(buy = buy - order.priceNumerator)
 
 			case _ if order.side == Side.Sell & order.volume > 0 =>
-			copy(sell = sell + (order.priceNumerator -> order.volume), lastMsg = order)
+			copy(sell = sell + (order.priceNumerator -> order.volume))
 
 			case _ if order.side == Side.Sell & order.volume == 0 =>
-			copy(sell = sell - order.priceNumerator, lastMsg = order)
+			copy(sell = sell - order.priceNumerator)
 
-			case _ if order.side == Side.NA => copy(lastMsg = order)
+			case _ if order.side == Side.NA => this
 			}
 	}
 

--- a/src/main/scala/com/scalafi/openbook/orderbook/OrderBook.scala
+++ b/src/main/scala/com/scalafi/openbook/orderbook/OrderBook.scala
@@ -2,51 +2,84 @@ package com.scalafi.openbook.orderbook
 
 import scala.collection.immutable.TreeMap
 import com.scalafi.openbook.{Side, OpenBookMsg}
+import scala.collection.mutable.HashSet
+import scala.collection.mutable.HashMap
 
 object OrderBook {
 
-  def empty(symbol: String): OrderBook = new OrderBook(symbol)
+	def empty(symbol: String): OrderBook = new OrderBook(symbol)
 
-  def fromOrders(symbol: String, orders: Iterator[OpenBookMsg]): Iterator[OrderBook] = {
-    val ob = empty(symbol)
-    orders.map { ob.update(_) }
-  }
+	/**
+	 * Time series of OrderBook for a stream of order messages for a single symbol:
+	 */
+	def fromOrders(symbol: String, orders: Iterator[OpenBookMsg]): Iterator[OrderBook] = {
+		val ob = empty(symbol);
+		orders filter(_.symbol.equals(symbol)) map { ob.update(_) }
+	}
+
+	/**
+	 * Time series of OrderBooks for a stream of order messages for a multiple symbols:
+	 */
+	def fromOrders(orders: Iterator[OpenBookMsg]): Iterator[OrderBook] = {
+		val obs = new HashMap[String, OrderBook];
+		orders map { 
+			msg => {
+				val sym = msg.symbol;
+
+				// get order book for this symbol, if it exists, else create new one 
+        // (un-idiomatic old people style):
+				val ob : OrderBook = 
+						if (obs.contains(sym)) {
+							obs.get(sym).get
+						}
+						else {
+							val ob1 = empty(sym);
+							obs.put(sym, ob1)
+							ob1
+						};
+
+						ob.update(msg)
+			}
+		}
+	}
 }
 
 case class OrderBook(symbol: String,
-                     buy: TreeMap[Int, Int] = TreeMap.empty,
-                     sell: TreeMap[Int, Int] = TreeMap.empty) {
+		buy: TreeMap[Int, Int] = TreeMap.empty,
+		sell: TreeMap[Int, Int] = TreeMap.empty,
+    lastMsg : OpenBookMsg = null // old people style, crusty and fast
+    ) {
 
-  def update(order: OpenBookMsg): OrderBook = {
-    assume(order.symbol == symbol, s"Unexpected order symbol: ${order.symbol}. In Order Book for: $symbol")
+	def update(order: OpenBookMsg): OrderBook = {
+			assume(order.symbol == symbol, s"Unexpected order symbol: ${order.symbol}. In Order Book for: $symbol")
 
-    order match {
-      case _ if order.side == Side.Buy & order.volume > 0 =>
-        copy(buy = buy + (order.priceNumerator -> order.volume))
+			order match {
+			case _ if order.side == Side.Buy & order.volume > 0 =>
+			copy(buy = buy + (order.priceNumerator -> order.volume), lastMsg = order)
 
-      case _ if order.side == Side.Buy & order.volume == 0 =>
-        copy(buy = buy - order.priceNumerator)
+			case _ if order.side == Side.Buy & order.volume == 0 =>
+			copy(buy = buy - order.priceNumerator, lastMsg = order)
 
-      case _ if order.side == Side.Sell & order.volume > 0 =>
-        copy(sell = sell + (order.priceNumerator -> order.volume))
+			case _ if order.side == Side.Sell & order.volume > 0 =>
+			copy(sell = sell + (order.priceNumerator -> order.volume), lastMsg = order)
 
-      case _ if order.side == Side.Sell & order.volume == 0 =>
-        copy(sell = sell - order.priceNumerator)
+			case _ if order.side == Side.Sell & order.volume == 0 =>
+			copy(sell = sell - order.priceNumerator, lastMsg = order)
 
-      case _ if order.side == Side.NA => this
-    }
-  }
+			case _ if order.side == Side.NA => copy(lastMsg = order)
+			}
+	}
 
-  def printOrderBook(depth: Int): String = {
+	def printOrderBook(depth: Int): String = {
 
-    val bid = buy.keySet.drop(buy.size - depth).map(price => s"$price : ${buy(price)}")
-    val ask = sell.keySet.take(depth).map(price => s"$price : ${sell(price)}")
+			val bid = buy.keySet.drop(buy.size - depth).map(price => s"$price : ${buy(price)}");
+			val ask = sell.keySet.take(depth).map(price => s"$price : ${sell(price)}");
 
-    s"""|Bid
-        |${bid.mkString(System.lineSeparator())}
-        |- - - - - - - - - -
-        |Ask
-        |${ask.mkString(System.lineSeparator())}
-        |""".stripMargin.trim
-  }
+			s"""|Bid
+			|${bid.mkString(System.lineSeparator())}
+			|- - - - - - - - - -
+			|Ask
+			|${ask.mkString(System.lineSeparator())}
+			|""".stripMargin.trim
+	}
 }

--- a/src/main/scala/com/scalafi/openbook/orderbook/OrderBook.scala
+++ b/src/main/scala/com/scalafi/openbook/orderbook/OrderBook.scala
@@ -47,7 +47,8 @@ object OrderBook {
 
 case class OrderBook(symbol: String,
 		buy: TreeMap[Int, Int] = TreeMap.empty,
-		sell: TreeMap[Int, Int] = TreeMap.empty
+		sell: TreeMap[Int, Int] = TreeMap.empty,
+    lastMsg : OpenBookMsg = null
     ) {
 
 	def update(order: OpenBookMsg): OrderBook = {
@@ -55,18 +56,18 @@ case class OrderBook(symbol: String,
 
 			order match {
 			case _ if order.side == Side.Buy & order.volume > 0 =>
-			copy(buy = buy + (order.priceNumerator -> order.volume))
+			copy(buy = buy + (order.priceNumerator -> order.volume), lastMsg = order)
 
 			case _ if order.side == Side.Buy & order.volume == 0 =>
-			copy(buy = buy - order.priceNumerator)
+			copy(buy = buy - order.priceNumerator, lastMsg = order)
 
 			case _ if order.side == Side.Sell & order.volume > 0 =>
-			copy(sell = sell + (order.priceNumerator -> order.volume))
+			copy(sell = sell + (order.priceNumerator -> order.volume), lastMsg = order)
 
 			case _ if order.side == Side.Sell & order.volume == 0 =>
-			copy(sell = sell - order.priceNumerator)
+			copy(sell = sell - order.priceNumerator, lastMsg = order)
 
-			case _ if order.side == Side.NA => this
+			case _ if order.side == Side.NA => copy(lastMsg = order)
 			}
 	}
 

--- a/src/main/scala/com/scalafi/openbook/orderbook/OrderBook.scala
+++ b/src/main/scala/com/scalafi/openbook/orderbook/OrderBook.scala
@@ -7,80 +7,80 @@ import scala.collection.mutable.HashMap
 
 object OrderBook {
 
-	def empty(symbol: String): OrderBook = new OrderBook(symbol)
+  def empty(symbol: String): OrderBook = new OrderBook(symbol)
 
-	/**
-	 * Time series of OrderBook for a stream of order messages for a single symbol:
-	 */
-	def fromOrders(symbol: String, orders: Iterator[OpenBookMsg]): Iterator[OrderBook] = {
-		val ob = empty(symbol);
-		orders filter(_.symbol.equals(symbol)) map { ob.update(_) }
-	}
+  /**
+   * Time series of OrderBook for a stream of order messages for a single symbol:
+   */
+  def fromOrders(symbol: String, orders: Iterator[OpenBookMsg]): Iterator[OrderBook] = {
+    val ob = empty(symbol);
+    orders filter(_.symbol.equals(symbol)) map { ob.update(_) }
+  }
 
-	/**
-	 * Time series of OrderBooks for a stream of order messages for a multiple symbols.
+  /**
+   * Time series of OrderBooks for a stream of order messages for a multiple symbols.
    * The iterator will always return the order book corresponding to the most recent message.
-	 */
-	def fromOrders(orders: Iterator[OpenBookMsg]): Iterator[OrderBook] = {
-		val obs = new HashMap[String, OrderBook];
-		orders map { 
-			msg => {
-				val sym = msg.symbol;
+   */
+  def fromOrders(orders: Iterator[OpenBookMsg]): Iterator[OrderBook] = {
+    val obs = new HashMap[String, OrderBook];
+    orders map { 
+      msg => {
+        val sym = msg.symbol;
 
-				// get order book for this symbol, if it exists, else create new one 
+        // get order book for this symbol, if it exists, else create new one 
         // (un-idiomatic old people style):
-				val ob : OrderBook = 
-						if (obs.contains(sym)) {
-							obs.get(sym).get
-						}
-						else {
-							val ob1 = empty(sym);
-							obs.put(sym, ob1)
-							ob1
-						};
+        val ob : OrderBook = 
+            if (obs.contains(sym)) {
+              obs.get(sym).get
+            }
+            else {
+              val ob1 = empty(sym);
+              obs.put(sym, ob1)
+              ob1
+            };
 
-						ob.update(msg)
-			}
-		}
-	}
+            ob.update(msg)
+      }
+    }
+  }
 }
 
 case class OrderBook(symbol: String,
-		buy: TreeMap[Int, Int] = TreeMap.empty,
-		sell: TreeMap[Int, Int] = TreeMap.empty,
+    buy: TreeMap[Int, Int] = TreeMap.empty,
+    sell: TreeMap[Int, Int] = TreeMap.empty,
     lastMsg : OpenBookMsg = null
     ) {
 
-	def update(order: OpenBookMsg): OrderBook = {
-			assume(order.symbol == symbol, s"Unexpected order symbol: ${order.symbol}. In Order Book for: $symbol")
+  def update(order: OpenBookMsg): OrderBook = {
+      assume(order.symbol == symbol, s"Unexpected order symbol: ${order.symbol}. In Order Book for: $symbol")
 
-			order match {
-			case _ if order.side == Side.Buy & order.volume > 0 =>
-			copy(buy = buy + (order.priceNumerator -> order.volume), lastMsg = order)
+      order match {
+      case _ if order.side == Side.Buy & order.volume > 0 =>
+      copy(buy = buy + (order.priceNumerator -> order.volume), lastMsg = order)
 
-			case _ if order.side == Side.Buy & order.volume == 0 =>
-			copy(buy = buy - order.priceNumerator, lastMsg = order)
+      case _ if order.side == Side.Buy & order.volume == 0 =>
+      copy(buy = buy - order.priceNumerator, lastMsg = order)
 
-			case _ if order.side == Side.Sell & order.volume > 0 =>
-			copy(sell = sell + (order.priceNumerator -> order.volume), lastMsg = order)
+      case _ if order.side == Side.Sell & order.volume > 0 =>
+      copy(sell = sell + (order.priceNumerator -> order.volume), lastMsg = order)
 
-			case _ if order.side == Side.Sell & order.volume == 0 =>
-			copy(sell = sell - order.priceNumerator, lastMsg = order)
+      case _ if order.side == Side.Sell & order.volume == 0 =>
+      copy(sell = sell - order.priceNumerator, lastMsg = order)
 
-			case _ if order.side == Side.NA => copy(lastMsg = order)
-			}
-	}
+      case _ if order.side == Side.NA => copy(lastMsg = order)
+      }
+  }
 
-	def printOrderBook(depth: Int): String = {
+  def printOrderBook(depth: Int): String = {
 
-			val bid = buy.keySet.drop(buy.size - depth).map(price => s"$price : ${buy(price)}");
-			val ask = sell.keySet.take(depth).map(price => s"$price : ${sell(price)}");
+      val bid = buy.keySet.drop(buy.size - depth).map(price => s"$price : ${buy(price)}");
+      val ask = sell.keySet.take(depth).map(price => s"$price : ${sell(price)}");
 
-			s"""|Bid
-			|${bid.mkString(System.lineSeparator())}
-			|- - - - - - - - - -
-			|Ask
-			|${ask.mkString(System.lineSeparator())}
-			|""".stripMargin.trim
-	}
+      s"""|Bid
+      |${bid.mkString(System.lineSeparator())}
+      |- - - - - - - - - -
+      |Ask
+      |${ask.mkString(System.lineSeparator())}
+      |""".stripMargin.trim
+  }
 }

--- a/src/test/scala/com/scalafi/openbook/orderbook/OrderBookSpec.scala
+++ b/src/test/scala/com/scalafi/openbook/orderbook/OrderBookSpec.scala
@@ -48,8 +48,10 @@ class OrderBookSpec extends FlatSpec with GivenWhenThen {
 
   }
   
-  it should "build valid stream of order books either a stream of messages corresponding to different symbols " in {
-    val is = this.getClass.getResourceAsStream("/openbookultraAA_N20130403_1_of_1")
+  it should "also support a stream of messages corresponding to different symbols " in {
+    def is = this.getClass.getResourceAsStream("/openbookultraAA_N20130403_1_of_1")
+    
+    Then("the number of symbols for in the message stream should match the number of symbols in the order book stream")
     val symbolsInMessages = OpenBookMsg.iterate(is).map(_.symbol).toSet
     val symbolsInOrderBooks = OrderBook.fromOrders(OpenBookMsg.iterate(is)).map(_.lastMsg.symbol).toSet
 

--- a/src/test/scala/com/scalafi/openbook/orderbook/OrderBookSpec.scala
+++ b/src/test/scala/com/scalafi/openbook/orderbook/OrderBookSpec.scala
@@ -13,7 +13,7 @@ class OrderBookSpec extends FlatSpec with GivenWhenThen {
     val order3 = orderMsg(200, 0, 11000, 20, Side.Sell)
 
     Then("correct order books should be constructed")
-    val orderBook = OrderBook(Symbol).update(order1).update(order2).update(order3)
+    val orderBook = OrderBook(SYMBOL_APL).update(order1).update(order2).update(order3)
 
     assert(orderBook.buy.size == 1)
     assert(orderBook.sell.size == 1)
@@ -28,7 +28,7 @@ class OrderBookSpec extends FlatSpec with GivenWhenThen {
     assert(orderBookUpd.sell.size == 2)
   }
 
-  it should "build valid stream of order books" in {
+  it should "build valid stream of order books either for a single symbol " in {
 
     Given("three orders")
     val order1 = orderMsg(0, 0, 10000, 10, Side.Buy)
@@ -38,7 +38,7 @@ class OrderBookSpec extends FlatSpec with GivenWhenThen {
     val orders: Iterator[OpenBookMsg] = Seq(order1, order2, order3).iterator
 
     Then("stream of three order books should be created")
-    val orderBooks = OrderBook.fromOrders(Symbol, orders)
+    val orderBooks = OrderBook.fromOrders(SYMBOL_APL, orders)
 
     assert(orderBooks.next().buy.get(order1.priceNumerator).get == order1.volume)
     assert(orderBooks.next().buy.get(order2.priceNumerator).get == order2.volume)
@@ -46,5 +46,13 @@ class OrderBookSpec extends FlatSpec with GivenWhenThen {
     
     assert(!orderBooks.hasNext)
 
+  }
+  
+  it should "build valid stream of order books either a stream of messages corresponding to different symbols " in {
+    val is = this.getClass.getResourceAsStream("/openbookultraAA_N20130403_1_of_1")
+    val symbolsInMessages = OpenBookMsg.iterate(is).map(_.symbol).toSet
+    val symbolsInOrderBooks = OrderBook.fromOrders(OpenBookMsg.iterate(is)).map(_.lastMsg.symbol).toSet
+
+    assert(symbolsInMessages.intersect(symbolsInOrderBooks).size == symbolsInMessages.size)
   }
 }

--- a/src/test/scala/com/scalafi/openbook/orderbook/package.scala
+++ b/src/test/scala/com/scalafi/openbook/orderbook/package.scala
@@ -2,14 +2,14 @@ package com.scalafi.openbook
 
 package object orderbook {
 
-  val Symbol = "APL"
+  val SYMBOL_APL = "APL" : String
 
   def orderMsg(sourceTime: Int, sourceTimeMicroSecs: Short, price: Int, volume: Int, side: Side) =
     OpenBookMsg(
       msgSeqNum = 0,
       msgType = MsgType.DeltaUpdate,
       sendTime = 0,
-      symbol = Symbol,
+      symbol = SYMBOL_APL,
       msgSize = 46,
       securityIndex = 0,
       sourceTime = sourceTime + 300000,


### PR DESCRIPTION
Basically, a TAQ file will contain messages corresponding to multiple symbols. My use case involves transforming that into a stream of order book states.

This is accomplished in the present patch by way of the following:
- add reference to last `OpenBookMsg` to the `OrderBook` (initial state being `null`, though that should rarely ever matter), this has the additional advantage of e.g. carrying across time stamp information and trading states,
- an extra method `OrderBook.fromOrders` which does _not_ take a symbol argument, but rather maintains a set of order books internally, and creates them on the fly.

The indentation in the patch below looks weird by the way. It's not at all what it looks like in my eclipse plugin. If it disturbs you, please comment. Or perhaps it's just github's diffing?
